### PR TITLE
Ensure backend is loading already selected image

### DIFF
--- a/Plugin/Cms/Model/Page/DataProvider/AfterGetData/ModifyBannerDataPlugin.php
+++ b/Plugin/Cms/Model/Page/DataProvider/AfterGetData/ModifyBannerDataPlugin.php
@@ -44,7 +44,7 @@ class ModifyBannerDataPlugin
         $loadedData
     ) {
         /** @var array $loadedData */
-        if (is_array($loadedData) && count($loadedData) == 1) {
+        if (is_array($loadedData)) {
             foreach ($loadedData as $key => $item) {
                 if (isset($item['banner_image']) && $item['banner_image']) {
                     $imageArr = [];


### PR DESCRIPTION
# Prerequisite
* Magento 2.4.0

# Problem
If for a CMS page an image is already selected, the upload - and therefore also the possibility to remove the selected image - isn't shown in the backend anymore.

# Solution
Don't change `DataProvider` only if there's one element, but take all into account.

The `$loadedData` includes all CMS pages present in the system. Checking if there's only one element in `$loadedData` would only add the already selected image if there's only one CMS page in the system.