### PR TITLE
Set page data correctly

### DIFF
--- a/Plugin/Cms/Model/PageRepository/BeforeSave/SaveBannerImagePlugin.php
+++ b/Plugin/Cms/Model/PageRepository/BeforeSave/SaveBannerImagePlugin.php
@@ -72,11 +72,10 @@ class SaveBannerImagePlugin
                     }
                 }
             }
-
-            $page->setData($data);
         } else {
             $data[$key] = null;
         }
+        $page->setData($data);
 
         return [$page];
     }


### PR DESCRIPTION
# Prerequisites
* Magento 2.4.0

# Problem
If image is deleted in backend, it isn't deleted at all.
This is due to the fact that if the image is deleted no `banner_image` is present in the `$data` at all. As `$page->setData($data)` only is performed if the key is set, the deletion doesn't make it's way to the database.

# Solution
Perform `$page->setData($data)` after *all* possible cases for modifying data.